### PR TITLE
Allow installation on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Przelewy24 payment plugin for Sylius applications.",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "sylius/sylius": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
We just have Sylius 1.10 alpha 1 with support for PHP 8, so we need to allow it in plugins too.