### PR TITLE
Allow retry of payment for orders with status CREATED

### DIFF
--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -56,7 +56,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Generic
 
         $details = $request->getModel();
 
-        if (isset($details['p24_status'])) {
+        if (isset($details['p24_status']) && $details['p24_status'] !== Przelewy24BridgeInterface::CREATED_STATUS) {
             return;
         }
 


### PR DESCRIPTION
---

#### What is the problem?  
When a payment attempt is initiated but not completed (user leaves PSP page), the plugin sets `p24_status` and then blocks any further retries from the storefront or customer account because the code returns whenever `p24_status` is defined, regardless of its value.

---

#### How to reproduce  
1. Place an order using the Przelewy24 payment option.  
2. At the redirect to the PSP, **quit** the page without completing the payment.  
3. Go to Your account, then Order History, and then **Retry Payment**.  
4. No redirect to the PSP occurs (the code returns early) and then you are redirected to payment success confirmation page instead of PSP.

---

#### Proposed solution  
Only block access to the PSP when the payment status is set **and** not equal to `created`.

```diff
--- src/Action/CaptureAction.php
+++ src/Action/CaptureAction.php
@@ public function execute($request): void
-    if (isset($details['p24_status'])) {
-        return;
-    }
+    if (isset($details['p24_status']) && $details['p24_status'] !== Przelewy24BridgeInterface::CREATED_STATUS) {
+        return;
+    }
```

This change ensures that when p24_status === created (for example if the first attempt is incomplete), the flow continues and redirects back to the PSP for retry.